### PR TITLE
SLING-7669 StartupManager overwrites the frameworkstartlevel property…

### DIFF
--- a/src/main/java/org/apache/sling/launchpad/base/impl/StartupManager.java
+++ b/src/main/java/org/apache/sling/launchpad/base/impl/StartupManager.java
@@ -80,6 +80,14 @@ public class StartupManager {
             this.logger.log(Logger.LOG_INFO, "Detected startup mode. Starting in mode " + this.mode);
         }
 
+        // populate the sling target start level from the framework one, if not set,
+        // otherwise overwrite the framework one
+        if (null == properties.get(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL)) {
+            properties.put(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL, properties.get(Constants.FRAMEWORK_BEGINNING_STARTLEVEL));
+        } else {
+            properties.put(Constants.FRAMEWORK_BEGINNING_STARTLEVEL, properties.get(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL));
+        }
+
         this.targetStartLevel = Long.valueOf(properties.get(Constants.FRAMEWORK_BEGINNING_STARTLEVEL));
 
         this.incrementalStartupEnabled = Boolean.valueOf(properties.get(SharedConstants.SLING_INSTALL_INCREMENTAL_START));

--- a/src/main/java/org/apache/sling/launchpad/base/impl/StartupManager.java
+++ b/src/main/java/org/apache/sling/launchpad/base/impl/StartupManager.java
@@ -82,7 +82,7 @@ public class StartupManager {
 
         // populate the sling target start level from the framework one, if not set,
         // otherwise overwrite the framework one
-        if (properties.containsKey(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL)) {
+        if (!properties.containsKey(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL)) {
             properties.put(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL, properties.get(Constants.FRAMEWORK_BEGINNING_STARTLEVEL));
         } else {
             properties.put(Constants.FRAMEWORK_BEGINNING_STARTLEVEL, properties.get(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL));

--- a/src/main/java/org/apache/sling/launchpad/base/impl/StartupManager.java
+++ b/src/main/java/org/apache/sling/launchpad/base/impl/StartupManager.java
@@ -82,7 +82,7 @@ public class StartupManager {
 
         // populate the sling target start level from the framework one, if not set,
         // otherwise overwrite the framework one
-        if (null == properties.get(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL)) {
+        if (properties.containsKey(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL)) {
             properties.put(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL, properties.get(Constants.FRAMEWORK_BEGINNING_STARTLEVEL));
         } else {
             properties.put(Constants.FRAMEWORK_BEGINNING_STARTLEVEL, properties.get(SharedConstants.SLING_INSTALL_TARGETSTARTLEVEL));

--- a/src/main/java/org/apache/sling/launchpad/base/shared/SharedConstants.java
+++ b/src/main/java/org/apache/sling/launchpad/base/shared/SharedConstants.java
@@ -132,7 +132,7 @@ public interface SharedConstants {
      * The name of the configuration property defining the startlevel
      * for installs and updates. The framework starts with this start level
      * and the startup manager increases the start level one by one until
-     * thetarget start level is reached ({@value #SLING_INSTALL_TARGETSTARTLEVEL}).
+     * the target start level is reached ({@value #SLING_INSTALL_TARGETSTARTLEVEL}).
      * This level is only used if {@link #SLING_INSTALL_INCREMENTAL_START} is
      * enabled. Default value is 10.
      * @since 2.4.0

--- a/src/main/java/org/apache/sling/launchpad/base/shared/SharedConstants.java
+++ b/src/main/java/org/apache/sling/launchpad/base/shared/SharedConstants.java
@@ -132,10 +132,19 @@ public interface SharedConstants {
      * The name of the configuration property defining the startlevel
      * for installs and updates. The framework starts with this start level
      * and the startup manager increases the start level one by one until
-     * the initial framework start level is reached (value is "sling.framework.install.startlevel").
+     * thetarget start level is reached ({@value #SLING_INSTALL_TARGETSTARTLEVEL}).
      * This level is only used if {@link #SLING_INSTALL_INCREMENTAL_START} is
      * enabled. Default value is 10.
      * @since 2.4.0
      */
     public static final String SLING_INSTALL_STARTLEVEL = "sling.framework.install.startlevel";
+
+    /**
+     * The name of the configuration property defining the target startlevel
+     * The framework starts with the startlevel of {@value #SLING_INSTALL_STARTLEVEL}
+     * and the stops when it reaches this level
+     * Default value is the value of the osgi initial framework start level
+     * @see {@link #SLING_INSTALL_STARTLEVEL}
+     */
+    public static final String SLING_INSTALL_TARGETSTARTLEVEL = "sling.framework.install.targetstartlevel";
 }


### PR DESCRIPTION
… and there is no way to retrieve the intended target start level

