### PR TITLE
SLING-12537 Strings and Boxed types should be compared using "equals()"

### DIFF
--- a/src/main/java/org/apache/sling/launchpad/app/Main.java
+++ b/src/main/java/org/apache/sling/launchpad/app/Main.java
@@ -733,7 +733,7 @@ public class Main {
                 String value = arg.getValue();
                 switch (arg.getKey().charAt(0)) {
                     case 'j':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-j", "Missing host:port value");
                             errorArg = true;
                             continue;
@@ -742,7 +742,7 @@ public class Main {
                         break;
 
                     case 'l':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-l", "Missing log level value");
                             errorArg = true;
                             continue;
@@ -751,7 +751,7 @@ public class Main {
                         break;
 
                     case 'f':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-f", "Missing log file value");
                             errorArg = true;
                             continue;
@@ -762,7 +762,7 @@ public class Main {
                         break;
 
                     case 'c':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-c", "Missing directory value");
                             errorArg = true;
                             continue;
@@ -771,7 +771,7 @@ public class Main {
                         break;
 
                     case 'i':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-i", "Missing launchpad directory value");
                             errorArg = true;
                             continue;
@@ -780,7 +780,7 @@ public class Main {
                         break;
 
                     case 'a':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-a", "Missing address value");
                             errorArg = true;
                             continue;
@@ -789,7 +789,7 @@ public class Main {
                         break;
 
                     case 'p':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-p", "Missing port value");
                             errorArg = true;
                             continue;
@@ -805,7 +805,7 @@ public class Main {
                         break;
 
                     case 'r':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-r", "Missing root path value");
                             errorArg = true;
                             continue;
@@ -818,7 +818,7 @@ public class Main {
                         break;
 
                     case 'D':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             errorArg("-D", "Missing property assignment");
                             errorArg = true;
                             continue;

--- a/src/main/java/org/apache/sling/launchpad/base/app/MainDelegate.java
+++ b/src/main/java/org/apache/sling/launchpad/base/app/MainDelegate.java
@@ -237,7 +237,7 @@ public class MainDelegate implements Launcher {
                 String value = arg.getValue();
                 switch (arg.getKey().charAt(0)) {
                     case 'l':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             terminate("Missing log level value", 1);
                             continue;
                         }
@@ -245,7 +245,7 @@ public class MainDelegate implements Launcher {
                         break;
 
                     case 'f':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             terminate("Missing log file value", 1);
                             continue;
                         } else if ("-".equals(value)) {
@@ -255,7 +255,7 @@ public class MainDelegate implements Launcher {
                         break;
 
                     case 'c':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             terminate("Missing directory value", 1);
                             continue;
                         }
@@ -263,7 +263,7 @@ public class MainDelegate implements Launcher {
                         break;
 
                     case 'p':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             terminate("Missing port value", 1);
                             continue;
                         }
@@ -277,7 +277,7 @@ public class MainDelegate implements Launcher {
                         break;
 
                     case 'a':
-                        if (value == arg.getKey()) {
+                        if (value.equals(arg.getKey())) {
                             terminate("Missing address value", 1);
                             continue;
                         }


### PR DESCRIPTION
This fixes 14 Sonarqube violations of rule S4973:
https://rules.sonarsource.com/java/RSPEC-4973

Sonarcloud violation URL:
https://sonarcloud.io/organizations/apache/issues?languages=java&open=AWo4wjwAnu96bB9fOyWP&resolved=false&rules=squid%3AS4973&types=BUG

Jira Ticket:
https://issues.apache.org/jira/browse/SLING-8825