### PR TITLE
SLING-11975 upgrade maven-bundle-plugin to 5.1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.1</version>
+                <version>5.1.9</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/SLING-11975

maven-bundle-plugin-5.1.5 is the earliest version with Bnd >= 5.3, but this failed to build the project. I upgraded it to the latest minor version instead (5.1.9). 