### PR TITLE
SLING-12829 - Sling launchpad ignores startlevel change of startup di…

### DIFF
--- a/src/main/java/org/apache/sling/launchpad/base/impl/BootstrapInstaller.java
+++ b/src/main/java/org/apache/sling/launchpad/base/impl/BootstrapInstaller.java
@@ -446,7 +446,7 @@ class BootstrapInstaller {
 
         // check for an installed Bundle with the symbolic name
         Bundle installedBundle = currentBundles.get(symbolicName);
-        if (ignore(installedBundle, manifest)) {
+        if (ignore(installedBundle, startLevel, manifest)) {
             logger.log(Logger.LOG_INFO, "Ignoring " + bundleJar + ": More recent version already installed");
             return false; // SHORT CIRCUIT
         }
@@ -602,10 +602,16 @@ class BootstrapInstaller {
      * @return <code>true</code> if the manifest does not describe a bundle with
      *         a higher version number.
      */
-    private boolean ignore(final Bundle installedBundle, final Manifest manifest) {
+    private boolean ignore(final Bundle installedBundle, int startLevel, final Manifest manifest) {
 
         // the bundle is not installed yet, so we have to install it
         if (installedBundle == null) {
+            return false;
+        }
+
+        int installedBundleStartLevel =
+                installedBundle.adapt(BundleStartLevel.class).getStartLevel();
+        if (startLevel != installedBundleStartLevel) {
             return false;
         }
 

--- a/src/main/java/org/apache/sling/launchpad/base/impl/BootstrapInstaller.java
+++ b/src/main/java/org/apache/sling/launchpad/base/impl/BootstrapInstaller.java
@@ -624,7 +624,7 @@ class BootstrapInstaller {
             return false;
         }
 
-        if (newVersion.compareTo(installedVersion) == 0) {
+        if (newVersion.equals(installedVersion)) {
             int installedBundleStartLevel =
                     installedBundle.adapt(BundleStartLevel.class).getStartLevel();
             if (startLevel != installedBundleStartLevel) {

--- a/src/main/java/org/apache/sling/launchpad/base/impl/BootstrapInstaller.java
+++ b/src/main/java/org/apache/sling/launchpad/base/impl/BootstrapInstaller.java
@@ -609,12 +609,6 @@ class BootstrapInstaller {
             return false;
         }
 
-        int installedBundleStartLevel =
-                installedBundle.adapt(BundleStartLevel.class).getStartLevel();
-        if (startLevel != installedBundleStartLevel) {
-            return false;
-        }
-
         String versionProp = manifest.getMainAttributes().getValue(Constants.BUNDLE_VERSION);
         Version newVersion = Version.parseVersion(versionProp);
 
@@ -628,6 +622,14 @@ class BootstrapInstaller {
                 && isNewerSnapshot(installedBundle, manifest)) {
             logger.log(Logger.LOG_INFO, "Forcing upgrade of SNAPSHOT bundle: " + installedBundle.getSymbolicName());
             return false;
+        }
+
+        if (newVersion.compareTo(installedVersion) == 0) {
+            int installedBundleStartLevel =
+                    installedBundle.adapt(BundleStartLevel.class).getStartLevel();
+            if (startLevel != installedBundleStartLevel) {
+                return false;
+            }
         }
 
         return newVersion.compareTo(installedVersion) <= 0;

--- a/src/test/java/org/apache/sling/launchpad/base/impl/BootstrapInstallerTest.java
+++ b/src/test/java/org/apache/sling/launchpad/base/impl/BootstrapInstallerTest.java
@@ -48,8 +48,6 @@ import static org.mockito.Mockito.when;
  */
 public class BootstrapInstallerTest {
 
-    public static final String TEST_RESOURCE_PATH = "holaworld-invalid.jar";
-
     /**
      * Test method for
      * {@link org.apache.sling.launchpad.base.impl.BootstrapInstaller#extractFileName(java.lang.String)}

--- a/src/test/java/org/apache/sling/launchpad/base/impl/BootstrapInstallerTest.java
+++ b/src/test/java/org/apache/sling/launchpad/base/impl/BootstrapInstallerTest.java
@@ -202,15 +202,18 @@ public class BootstrapInstallerTest {
     }
 
     @Test
-    public void testIgnoreSameVersionSameStartLevel() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testIgnoreSameVersionSameStartLevel()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         // prepare for invoking the installBundle method
         BundleContext mockBundleContext = mock(BundleContext.class);
         Logger mockLogger = mock(Logger.class);
         LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
-        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+        BootstrapInstaller bsi =
+                new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
 
-        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        Method ignoreMethod =
+                BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
         ignoreMethod.setAccessible(true);
 
         // prepare already installed bundle
@@ -234,15 +237,18 @@ public class BootstrapInstallerTest {
     }
 
     @Test
-    public void testIgnoreSnapshotVersion() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testIgnoreSnapshotVersion()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         // prepare for invoking the installBundle method
         BundleContext mockBundleContext = mock(BundleContext.class);
         Logger mockLogger = mock(Logger.class);
         LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
-        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+        BootstrapInstaller bsi =
+                new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
 
-        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        Method ignoreMethod =
+                BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
         ignoreMethod.setAccessible(true);
 
         // prepare already installed bundle
@@ -266,15 +272,18 @@ public class BootstrapInstallerTest {
     }
 
     @Test
-    public void testIgnoreDifferentStartLevel() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testIgnoreDifferentStartLevel()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         // prepare for invoking the installBundle method
         BundleContext mockBundleContext = mock(BundleContext.class);
         Logger mockLogger = mock(Logger.class);
         LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
-        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+        BootstrapInstaller bsi =
+                new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
 
-        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        Method ignoreMethod =
+                BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
         ignoreMethod.setAccessible(true);
 
         // prepare already installed bundle
@@ -298,15 +307,18 @@ public class BootstrapInstallerTest {
     }
 
     @Test
-    public void testIgnoreNewBundleHigherVersion() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testIgnoreNewBundleHigherVersion()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         // prepare for invoking the installBundle method
         BundleContext mockBundleContext = mock(BundleContext.class);
         Logger mockLogger = mock(Logger.class);
         LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
-        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+        BootstrapInstaller bsi =
+                new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
 
-        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        Method ignoreMethod =
+                BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
         ignoreMethod.setAccessible(true);
 
         // prepare already installed bundle
@@ -330,15 +342,18 @@ public class BootstrapInstallerTest {
     }
 
     @Test
-    public void testIgnoreNewBundleLowerVersion() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testIgnoreNewBundleLowerVersion()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         // prepare for invoking the installBundle method
         BundleContext mockBundleContext = mock(BundleContext.class);
         Logger mockLogger = mock(Logger.class);
         LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
-        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+        BootstrapInstaller bsi =
+                new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
 
-        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        Method ignoreMethod =
+                BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
         ignoreMethod.setAccessible(true);
 
         // prepare already installed bundle
@@ -362,15 +377,18 @@ public class BootstrapInstallerTest {
     }
 
     @Test
-    public void testIgnoreNewBundleInstallation() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void testIgnoreNewBundleInstallation()
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         // prepare for invoking the installBundle method
         BundleContext mockBundleContext = mock(BundleContext.class);
         Logger mockLogger = mock(Logger.class);
         LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
-        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+        BootstrapInstaller bsi =
+                new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
 
-        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        Method ignoreMethod =
+                BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
         ignoreMethod.setAccessible(true);
 
         // new bundle to install

--- a/src/test/java/org/apache/sling/launchpad/base/impl/BootstrapInstallerTest.java
+++ b/src/test/java/org/apache/sling/launchpad/base/impl/BootstrapInstallerTest.java
@@ -23,15 +23,32 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
+import org.apache.felix.framework.Logger;
+import org.apache.sling.launchpad.api.LaunchpadContentProvider;
+import org.apache.sling.launchpad.api.StartupMode;
 import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.startlevel.BundleStartLevel;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Testing the bootstrap installer methods
  */
 public class BootstrapInstallerTest {
+
+    public static final String TEST_RESOURCE_PATH = "holaworld-invalid.jar";
 
     /**
      * Test method for
@@ -182,6 +199,184 @@ public class BootstrapInstallerTest {
 
         assertFalse(BootstrapInstaller.isBlank("Test"));
         assertFalse(BootstrapInstaller.isBlank(" asdf "));
+    }
+
+    @Test
+    public void testIgnoreSameVersionSameStartLevel() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // prepare for invoking the installBundle method
+        BundleContext mockBundleContext = mock(BundleContext.class);
+        Logger mockLogger = mock(Logger.class);
+        LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
+        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+
+        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        ignoreMethod.setAccessible(true);
+
+        // prepare already installed bundle
+        Bundle mockInstalledBundle = mock(Bundle.class);
+        Dictionary<String, String> headers = new Hashtable<>();
+        headers.put(Constants.BUNDLE_VERSION, "1.1.0");
+        when(mockInstalledBundle.getSymbolicName()).thenReturn("test.bundle");
+        when(mockInstalledBundle.getHeaders()).thenReturn(headers);
+
+        BundleStartLevel mockBundleStartLevel = mock(BundleStartLevel.class);
+        when(mockInstalledBundle.adapt(BundleStartLevel.class)).thenReturn(mockBundleStartLevel);
+        when(mockBundleStartLevel.getStartLevel()).thenReturn(1);
+
+        // new bundle to install
+        Attributes mockNewBundleAttributes = mock(Attributes.class);
+        when(mockNewBundleAttributes.getValue(Constants.BUNDLE_VERSION)).thenReturn("1.1.0");
+        Manifest mockNewBundleManifest = mock(Manifest.class);
+        when(mockNewBundleManifest.getMainAttributes()).thenReturn(mockNewBundleAttributes);
+
+        assertTrue((Boolean) ignoreMethod.invoke(bsi, mockInstalledBundle, 1, mockNewBundleManifest));
+    }
+
+    @Test
+    public void testIgnoreSnapshotVersion() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // prepare for invoking the installBundle method
+        BundleContext mockBundleContext = mock(BundleContext.class);
+        Logger mockLogger = mock(Logger.class);
+        LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
+        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+
+        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        ignoreMethod.setAccessible(true);
+
+        // prepare already installed bundle
+        Bundle mockInstalledBundle = mock(Bundle.class);
+        Dictionary<String, String> headers = new Hashtable<>();
+        headers.put(Constants.BUNDLE_VERSION, "1.1.0");
+        when(mockInstalledBundle.getSymbolicName()).thenReturn("test.bundle");
+        when(mockInstalledBundle.getHeaders()).thenReturn(headers);
+
+        BundleStartLevel mockBundleStartLevel = mock(BundleStartLevel.class);
+        when(mockInstalledBundle.adapt(BundleStartLevel.class)).thenReturn(mockBundleStartLevel);
+        when(mockBundleStartLevel.getStartLevel()).thenReturn(1);
+
+        // new bundle to install
+        Attributes mockNewBundleAttributes = mock(Attributes.class);
+        when(mockNewBundleAttributes.getValue(Constants.BUNDLE_VERSION)).thenReturn("1.1.0.SNAPSHOT");
+        Manifest mockNewBundleManifest = mock(Manifest.class);
+        when(mockNewBundleManifest.getMainAttributes()).thenReturn(mockNewBundleAttributes);
+
+        assertFalse((Boolean) ignoreMethod.invoke(bsi, mockInstalledBundle, 1, mockNewBundleManifest));
+    }
+
+    @Test
+    public void testIgnoreDifferentStartLevel() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // prepare for invoking the installBundle method
+        BundleContext mockBundleContext = mock(BundleContext.class);
+        Logger mockLogger = mock(Logger.class);
+        LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
+        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+
+        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        ignoreMethod.setAccessible(true);
+
+        // prepare already installed bundle
+        Bundle mockInstalledBundle = mock(Bundle.class);
+        Dictionary<String, String> headers = new Hashtable<>();
+        headers.put(Constants.BUNDLE_VERSION, "1.1.0");
+        when(mockInstalledBundle.getSymbolicName()).thenReturn("test.bundle");
+        when(mockInstalledBundle.getHeaders()).thenReturn(headers);
+
+        BundleStartLevel mockBundleStartLevel = mock(BundleStartLevel.class);
+        when(mockInstalledBundle.adapt(BundleStartLevel.class)).thenReturn(mockBundleStartLevel);
+        when(mockBundleStartLevel.getStartLevel()).thenReturn(20);
+
+        // new bundle to install
+        Attributes mockNewBundleAttributes = mock(Attributes.class);
+        when(mockNewBundleAttributes.getValue(Constants.BUNDLE_VERSION)).thenReturn("1.1.0");
+        Manifest mockNewBundleManifest = mock(Manifest.class);
+        when(mockNewBundleManifest.getMainAttributes()).thenReturn(mockNewBundleAttributes);
+
+        assertFalse((Boolean) ignoreMethod.invoke(bsi, mockInstalledBundle, 1, mockNewBundleManifest));
+    }
+
+    @Test
+    public void testIgnoreNewBundleHigherVersion() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // prepare for invoking the installBundle method
+        BundleContext mockBundleContext = mock(BundleContext.class);
+        Logger mockLogger = mock(Logger.class);
+        LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
+        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+
+        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        ignoreMethod.setAccessible(true);
+
+        // prepare already installed bundle
+        Bundle mockInstalledBundle = mock(Bundle.class);
+        Dictionary<String, String> headers = new Hashtable<>();
+        headers.put(Constants.BUNDLE_VERSION, "1.1.0");
+        when(mockInstalledBundle.getSymbolicName()).thenReturn("test.bundle");
+        when(mockInstalledBundle.getHeaders()).thenReturn(headers);
+
+        BundleStartLevel mockBundleStartLevel = mock(BundleStartLevel.class);
+        when(mockInstalledBundle.adapt(BundleStartLevel.class)).thenReturn(mockBundleStartLevel);
+        when(mockBundleStartLevel.getStartLevel()).thenReturn(1);
+
+        // new bundle to install
+        Attributes mockNewBundleAttributes = mock(Attributes.class);
+        when(mockNewBundleAttributes.getValue(Constants.BUNDLE_VERSION)).thenReturn("1.2.0");
+        Manifest mockNewBundleManifest = mock(Manifest.class);
+        when(mockNewBundleManifest.getMainAttributes()).thenReturn(mockNewBundleAttributes);
+
+        assertFalse((Boolean) ignoreMethod.invoke(bsi, mockInstalledBundle, 1, mockNewBundleManifest));
+    }
+
+    @Test
+    public void testIgnoreNewBundleLowerVersion() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // prepare for invoking the installBundle method
+        BundleContext mockBundleContext = mock(BundleContext.class);
+        Logger mockLogger = mock(Logger.class);
+        LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
+        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+
+        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        ignoreMethod.setAccessible(true);
+
+        // prepare already installed bundle
+        Bundle mockInstalledBundle = mock(Bundle.class);
+        Dictionary<String, String> headers = new Hashtable<>();
+        headers.put(Constants.BUNDLE_VERSION, "1.1.0");
+        when(mockInstalledBundle.getSymbolicName()).thenReturn("test.bundle");
+        when(mockInstalledBundle.getHeaders()).thenReturn(headers);
+
+        BundleStartLevel mockBundleStartLevel = mock(BundleStartLevel.class);
+        when(mockInstalledBundle.adapt(BundleStartLevel.class)).thenReturn(mockBundleStartLevel);
+        when(mockBundleStartLevel.getStartLevel()).thenReturn(1);
+
+        // new bundle to install
+        Attributes mockNewBundleAttributes = mock(Attributes.class);
+        when(mockNewBundleAttributes.getValue(Constants.BUNDLE_VERSION)).thenReturn("1.0.0");
+        Manifest mockNewBundleManifest = mock(Manifest.class);
+        when(mockNewBundleManifest.getMainAttributes()).thenReturn(mockNewBundleAttributes);
+
+        assertTrue((Boolean) ignoreMethod.invoke(bsi, mockInstalledBundle, 1, mockNewBundleManifest));
+    }
+
+    @Test
+    public void testIgnoreNewBundleInstallation() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        // prepare for invoking the installBundle method
+        BundleContext mockBundleContext = mock(BundleContext.class);
+        Logger mockLogger = mock(Logger.class);
+        LaunchpadContentProvider mockLaunchpadContentProvider = mock(LaunchpadContentProvider.class);
+        BootstrapInstaller bsi = new BootstrapInstaller(mockBundleContext, mockLogger, mockLaunchpadContentProvider, StartupMode.UPDATE);
+
+        Method ignoreMethod = BootstrapInstaller.class.getDeclaredMethod("ignore", Bundle.class, int.class, Manifest.class);
+        ignoreMethod.setAccessible(true);
+
+        // new bundle to install
+        Manifest mockNewBundleManifest = mock(Manifest.class);
+
+        assertFalse((Boolean) ignoreMethod.invoke(bsi, null, 1, mockNewBundleManifest));
     }
 
     // TODO eventually add in tests that create a context so we can test more


### PR DESCRIPTION
…rectory bundles

This PR enhances the bundle installation logic to also consider the bundle start level, ensuring that bundles with different start levels are not ignored during installation, even if their version match.